### PR TITLE
chore(ci): Add --skip-duplicate to NuGet push for idempotent re-runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
       - name: NuGet Push
         shell: pwsh
         run: |
-          dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_ORG_API_KEY }}"
+          dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_ORG_API_KEY }}" --skip-duplicate
 
   publish_nuget_prod:
     name: Publish NuGet Production
@@ -174,7 +174,7 @@ jobs:
       - name: NuGet Push
         shell: pwsh
         run: |
-          dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_ORG_API_KEY }}"
+          dotnet nuget push artifacts\*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_ORG_API_KEY }}" --skip-duplicate
 
   publish_extensions_prod:
     name: Publish Extensions Production


### PR DESCRIPTION
## Summary

Add `--skip-duplicate` flag to `dotnet nuget push` commands in CI workflows to make NuGet publish steps idempotent.

## Why

When re-running CI, publish jobs fail because the package version already exists. The `--skip-duplicate` flag allows safe re-runs without failing on already-published packages.

This is part of an org-wide effort to make all unoplatform repo CI publish steps resilient to re-runs after certificate rotation or transient failures.

Related to https://github.com/unoplatform/uno.templates/pull/2029