### PR TITLE
feat(updater): add built-in property-to-package fallback mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added tool allowing to display package dependencies
+- Built-in property-to-package fallback mappings for Uno legacy base packages (`UnoMaterial` → `Uno.Material.WinUI`, `UnoThemes` → `Uno.Themes.WinUI`, `UnoExtensions` → `Uno.Extensions.Core`). The fallback is gated by a suspicion check (only fires when the standard lookup returns nothing or a version older than the local reference), keeping behavior safe for direct references to legacy IDs. See `specs/property-package-fallback-mappings/spec.md`.
 ### Changed
 - Changed code structure to be able to share code between tools
 ### Fixed

--- a/doc/nuget-updater.md
+++ b/doc/nuget-updater.md
@@ -122,8 +122,48 @@ The nuget updater supports updating:
 - `.csproj`, `Directory.Build.props`, `Directory.Build.targets` and `Directory.Packages.props`
     For this type of files, the tool will update:
     - `PackageReference` and `PackageVersion` items
-    - MSBuild properties using named this way `UnoWinUIVersion` or `UnoExtensionsNavigationVersion`
+    - MSBuild properties named with the `Uno<PackageId>Version` convention (e.g. `UnoWinuiVersion`, `UnoExtensionsNavigationVersion`). The package ID is derived from the property name as described in [Property → package resolution](#property--package-resolution) below.
 - `.nuspec`
   For this type of files, the tool will update `reference` entries.
 - `global.json`
   For this type of files, the tool will update `msbuild-sdk` entries
+
+## Property → package resolution
+
+When a version is tracked via an MSBuild property (e.g. `<UnoMaterialVersion>7.0.0-dev.28</UnoMaterialVersion>`), the updater resolves the corresponding NuGet package ID in two complementary ways:
+
+1. **Explicit mapping (recommended for repo-specific cases).** Pass a JSON file via `--updateProperties=` listing `(PropertyName, PackageId)` pairs. See the `properties.json` example above. This is the authoritative path — the updater will treat the property's value as the version of the named package and update both in lockstep.
+
+2. **Name-derivation heuristic.** When no explicit mapping is provided, the updater derives a package ID from the property name by stripping the trailing `Version`, splitting at lowercase→uppercase boundaries, lowercasing, and joining with dots:
+
+   | Property | Derived package ID |
+   |---|---|
+   | `UnoWinuiVersion` | `uno.winui` |
+   | `UnoToolkitVersion` | `uno.toolkit` |
+   | `UnoMaterialVersion` | `uno.material` |
+   | `UnoExtensionsVersion` | `uno.extensions` |
+
+   **Property name casing matters.** The split happens at every lowercase→uppercase transition, so adjacent uppercase letters (acronyms) produce different IDs: `UnoWinuiVersion` derives to `uno.winui`, but `UnoWinUIVersion` derives to `uno.win.ui`. The lowercase-acronym form (`UnoWinuiVersion`) is what the modern Uno packages publish on NuGet.org and is the established convention across `unoplatform/*` repos. Several of them document it inline in `Directory.Build.props`:
+
+   ```xml
+   <!--
+   IMPORTANT: The `UnoWinuiVersion` and `UnoSettingsVersion` property
+   names follow a convention expected by the uno.nugetupdater. The casing
+   is significant in order for the package lookup to be performed properly
+   (e.g. UnoWinuiVersion instead of UnoWinUIVersion).
+   -->
+   ```
+
+   If your property uses acronym casing and the derived ID doesn't match a real package, prefer the lowercase-acronym form or use the explicit `--updateProperties=` override above.
+
+3. **Built-in well-known fallback table.** When the derived ID points at an outdated or deprecated base package on NuGet.org, the updater also consults a small built-in table of canonical replacements. The fallback's version is preferred only when it is *newer* than what the derived ID returns. Currently:
+
+   | Property fragment | Falls back to | Reason |
+   |---|---|---|
+   | `UnoMaterial` | `Uno.Material.WinUI` | Legacy `uno.material` (UWP era) is at v5.x; modern consumers reference the WinUI 3 variant. |
+   | `UnoThemes` | `Uno.Themes.WinUI` | Legacy `uno.themes` (UWP era) is at v5.x; modern consumers reference the WinUI 3 variant (and `Uno.Simple.WinUI` ships in lockstep). |
+   | `UnoExtensions` | `Uno.Extensions.Core` | Legacy umbrella `uno.extensions` is at v2.x; modern consumers reference the `Uno.Extensions.*` family (in lockstep, so `.Core` is a canonical lookup). |
+
+   No flag is required to enable the fallback table. If you need behavior that differs from these defaults for a specific repository, use `--updateProperties=` to declare the explicit `(PropertyName, PackageId)` you want.
+
+See [`specs/property-package-fallback-mappings/spec.md`](https://github.com/unoplatform/nuget.updater/blob/main/specs/property-package-fallback-mappings/spec.md) for the full design rationale and rollout plan. (Absolute link so the reference resolves from both the repo and a rendered docs site, since the `specs/` folder lives outside the docfx tree.)

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,53 @@
+# Specs
+
+Design specifications for non-trivial changes to the NuGet Updater tool and the supporting `NvGet` library.
+
+## When to add a spec
+
+Add a spec under a new `specs/<kebab-name>/` folder for any change that:
+
+- Introduces new behavior with non-obvious tradeoffs
+- Modifies the resolution algorithm, the discovery heuristic, or the public CLI / task surface
+- Coordinates with multiple downstream consumers (e.g. canary YAMLs across `unoplatform/*` repos)
+- Establishes a convention that other repos are expected to follow
+
+Trivial fixes (typos, dependency bumps, internal refactors that don't change behavior) do not need a spec.
+
+## Folder layout
+
+```
+specs/
+├── README.md                                   ← this file
+└── <feature-kebab-name>/
+    └── spec.md                                 ← single-file specs
+    └── (optionally) appendix-<topic>.md        ← longer multi-file specs
+```
+
+Use a short, descriptive, kebab-cased folder name. Unlike some Uno repos, this repo does not number its specs — keep folder names self-describing.
+
+## Spec contents
+
+At minimum:
+
+- **Status** (Proposed / Accepted / Implemented / Superseded)
+- **Summary** (1–2 sentences)
+- **Motivation** with concrete production evidence where applicable
+- **Design** (algorithm, API, interactions)
+- **Test plan** referencing the test classes / methods
+- **Rollout plan** if downstream coordination is required
+
+Optional but recommended for larger changes:
+
+- Industry alignment / prior-art comparison
+- Alternatives considered
+- Future work
+
+## Cross-referencing
+
+User-facing docs in `doc/` should link to the relevant spec with an **absolute GitHub URL** (e.g. `https://github.com/unoplatform/nuget.updater/blob/main/specs/...`) so the reference resolves from a rendered docfx site — the `specs/` folder lives outside the docfx tree.
+
+## Index
+
+| Spec | Status |
+|---|---|
+| [property-package-fallback-mappings](property-package-fallback-mappings/spec.md) | Proposed |

--- a/specs/property-package-fallback-mappings/spec.md
+++ b/specs/property-package-fallback-mappings/spec.md
@@ -1,0 +1,208 @@
+# Property → Package Fallback Mappings
+
+## Status
+Proposed — implemented on branch `dev/agzi/property-package-fallback-mappings`.
+
+## Summary
+Add a built-in, in-process fallback table that lets the NuGet Updater resolve the latest version of an MSBuild *version property* whose name-derived package ID points at an outdated or deprecated base package on NuGet.org. The fallback is consulted *after* the normal feed lookup and only "wins" when it yields a newer version than the heuristic-derived package. Behavior is purely additive — no public API changes, no breaking changes for existing consumers.
+
+## Motivation
+
+### Observed problem
+Multiple `unoplatform` canary build pipelines have been silently failing to bump well-known MSBuild version properties for months. Example from Uno Studio canary build [`213977`](https://dev.azure.com/uno-platform/uno-private/_build/results?buildId=213977):
+
+```
+Skipping uno.material:    version 7.0.0-dev.28 found in Directory.Build.props,
+                          version 5.8.0-dev.2  found in https://api.nuget.org/v3/index.json
+Skipping uno.extensions:  version 7.0.17       found in Directory.Build.props,
+                          version 3.0.0-dev.1957 found in https://api.nuget.org/v3/index.json
+```
+
+The updater's discovery heuristic (`src/NvGet/Extensions/XmlDocumentExtensions.cs`) turns the MSBuild property name into a lowercase, dot-separated package ID:
+
+```
+<UnoMaterialVersion>   → uno.material
+<UnoExtensionsVersion> → uno.extensions
+```
+
+These ID derivations are correct for the *legacy UWP-era* packages. But the projects actually reference modern WinUI/SubPackage variants (`Uno.Material.WinUI`, `Uno.Extensions.Core`, etc.) — packages whose version trajectory diverged from the legacy umbrella long ago:
+
+| MSBuild property | Heuristic-derived ID | Latest dev on NuGet.org | Actually referenced package(s) | Latest dev |
+|---|---|---|---|---|
+| `UnoMaterialVersion` | `uno.material` | `5.8.0-dev.2` (stale UWP) | `Uno.Material.WinUI` | `7.0.0-dev.33+` |
+| `UnoThemesVersion` | `uno.themes` | `5.8.0-dev.2` (stale UWP) | `Uno.Themes.WinUI`, `Uno.Simple.WinUI` (lockstep) | `7.0.0-dev.33+` |
+| `UnoExtensionsVersion` | `uno.extensions` | `3.0.0-dev.1957` (stale umbrella) | `Uno.Extensions.Core`, `Uno.Extensions.Hosting.WinUI`, … | `7.3.0-dev.78+` |
+
+Because the heuristic-derived ID returns a *lower* version than what's already in `Directory.Build.props`, the updater treats it as a non-upgrade and silently skips. The MSBuild property never advances, and the project drifts further behind every canary cycle until some other Uno canary package raises a transitive floor and a build breaks with `NU1605`.
+
+### Production evidence
+
+| Repo | Property | Failure mode |
+|---|---|---|
+| Uno Studio canary | `UnoMaterialVersion` | NU1605 — `Uno.Toolkit.WinUI.Material 9.0.0-dev.4` requires `Uno.Material.WinUI ≥ 7.0.0-dev.29` but `Directory.Build.props` was stuck at `7.0.0-dev.28` for 10+ nights |
+| Uno Studio canary | `UnoExtensionsVersion` | Latent — stuck at `7.0.17` (stable) while the family ships `7.3.0-dev.78+`. No failure yet because no transitive consumer has raised the floor — but it will. |
+| Uno.Toolkit canary | `UnoThemesVersion` | Latent — stuck at `7.0.0-dev.29` while `Uno.Themes.WinUI` ships `7.0.0-dev.33+`. Updater queries legacy `uno.themes` (stale at `5.8.0-dev.2`) and skips. Same risk profile as Material: NU1605 surfaces the moment Toolkit canary raises the floor. |
+| uno.extensions canary | `MauiUnoVersion`, `NonMauiUnoVersion` | Repo author noticed the issue and configured a `propertiesToUpdate.json` mapping file — but the ADO task input they used (`projectProperties:`) doesn't exist; their workaround has been silently no-op since 2025-08. |
+
+### Why a built-in?
+
+The existing `--updateProperties=` CLI argument (and the equivalent `useUpdateProperties: true` + `updatePropertiesFile:` ADO task inputs) already lets a repo declare explicit `(PropertyName, PackageId)` mappings. That mechanism is the correct "first-class" override path for repo-specific cases.
+
+But:
+
+1. **Most canary repos haven't configured it.** The mismatch is repository-spanning; expecting every repo owner to discover and apply the same workaround is unrealistic — uno.extensions is the cautionary tale.
+2. **The known mismatches are stable.** `uno.material` → `Uno.Material.WinUI` and `uno.extensions` → `Uno.Extensions.Core` are organizational facts, not project-specific ones.
+3. **Industry precedent supports built-in defaults.** Dependabot ships ecosystem-specific defaults; Renovate ships shared presets; arcade-services ships `eng/common/` defaults. The Uno tool was the outlier with a heuristic-only path.
+
+A small, hardcoded well-known table catches the common cases automatically — repos that want different behavior can still override with `--updateProperties=`.
+
+## Industry alignment
+
+| Tool | Approach to property/variable substitution | Built-in defaults |
+|---|---|---|
+| [Dependabot for NuGet](https://devblogs.microsoft.com/dotnet/the-new-dependabot-nuget-updater/) (2024+) | Real MSBuild evaluation | Yes — handles `$(...)` natively |
+| [Renovate `nuget` manager](https://docs.renovatebot.com/modules/manager/nuget/) | Literal version strings only; substitution is unsupported ([open since 2018](https://github.com/renovatebot/renovate/issues/2266)) | Shared presets via `extends:` |
+| [Maestro / arcade-services](https://github.com/dotnet/arcade/blob/main/Documentation/DependencyDescriptionFormat.md) | Explicit `Version.Details.xml` declarations | Centralized `eng/common/` |
+| [NuKeeper](https://github.com/NuKeeperDotNet/NuKeeper) (archived 2022) | Heuristic name-derivation, no fallback | None — the [unresolved issue](https://github.com/NuKeeperDotNet/NuKeeper/issues/478) that contributed to abandonment |
+
+Consistent design principle: **built-in defaults + explicit user override**. The proposed change moves Uno's tool from the NuKeeper-style heuristic-only design (which has a known failure trajectory) toward the Dependabot/Renovate pattern.
+
+## Design
+
+### Two existing mechanisms (unchanged)
+
+1. **`<PackageReference Include="X" Version="literal" />`** — direct reference discovery, exact lookup.
+2. **`--updateProperties=<file>.json` / `useUpdateProperties: true` + `updatePropertiesFile:`** — user-supplied `(PropertyName, PackageId)` pairs that *add* explicit references. This is the first-class user override.
+
+### One new mechanism
+
+3. **Built-in well-known property-fragment → fallback-package table.** Lives in `PropertyPackageMappings.WellKnownMappings`. Consulted in `UpdaterParametersExtension.GetLatestVersion` *after* the standard lookup; the fallback version is preferred only when it is *newer* than the standard result.
+
+### Resolution algorithm
+
+```
+GetLatestVersion(reference):
+  if VersionOverrides has reference.Id with forceVersion:
+    return that override.MinVersion  // (existing)
+
+  result := ResolveLatestVersion(reference)  // existing per-feed lookup
+
+  // Suspicion gate: only consider the fallback when the standard lookup looks broken
+  // (returned nothing, or returned a version OLDER than the reference's local version —
+  // the canary updater wouldn't have written a higher local version than the latest
+  // published unless the local file is tracking a different package via property indirection).
+  standardIsSuspicious := (result == null) OR (reference.Version > result.Version)
+
+  if standardIsSuspicious:
+    propertyFragment := ConvertPackageIdToPropertyFragment(reference.Id)
+    if WellKnownMappings contains propertyFragment:
+      (fallbackId, reason) := WellKnownMappings[propertyFragment]
+      fallbackResult := ResolveLatestVersion(reference with Id = fallbackId)
+      if fallbackResult is not null and (result is null or fallbackResult.Version > result.Version):
+        log "Applied property fallback mapping: {reference.Id} -> {fallbackId} ({reason})"
+        result := fallbackResult
+
+  return result
+```
+
+The **suspicion gate** is what makes the fallback safe in the presence of direct (non-property) references to legacy IDs. Without it, a repo that legitimately references `<PackageVersion Include="Uno.Material" Version="5.0.13" />` (e.g. uno.toolkit.ui) would have its version silently rewritten to `Uno.Material.WinUI`'s latest (7.x), which doesn't exist for the original package and would break restore. With the gate, the fallback only fires when the local version is *ahead* of what the standard lookup returns — a signal that the local file is tracking a different package via property indirection.
+
+Round-trip helper `ConvertPackageIdToPropertyFragment` is the inverse of the discovery heuristic in `XmlDocumentExtensions`: split by `.`, capitalize each part, concatenate. So `uno.material` → `UnoMaterial`, matching the property-fragment keying of `WellKnownMappings`.
+
+### Initial well-known table
+
+```csharp
+WellKnownMappings = {
+  ["UnoMaterial"]   → "Uno.Material.WinUI",
+  ["UnoThemes"]     → "Uno.Themes.WinUI",
+  ["UnoExtensions"] → "Uno.Extensions.Core",
+}
+```
+
+Excluded by intent:
+- `UnoToolkit` — `uno.toolkit` (parent package) still ships in lockstep with `Uno.Toolkit.WinUI*` family
+- `UnoWinui` — `uno.winui` *is* the modern package (case-insensitive ID match)
+- `UnoResizetizer` / `UnoTemplates` — single-package families, no divergence
+
+When a new property/package divergence is observed in the field, it can be added with a one-test, one-line PR.
+
+## Compatibility & risk
+
+| Concern | Assessment |
+|---|---|
+| API breakage | None. No public type or method signature changed. New file adds new public type but only as a single static table. |
+| Behavior change | Repos with `UnoMaterialVersion` / `UnoExtensionsVersion` properties will start auto-bumping where they previously silently skipped. This *is the fix*. |
+| Major version jumps | Repos that have been silently stuck (e.g. on the legacy `Uno.Material 5.x` track) will jump to the modern `Uno.Material.WinUI 7.x` track on first run. Canary is the safe surface to discover this; existing `--ignorePackages=` flag is the opt-out. |
+| Extra feed traffic | One additional `GetPackageVersions` call per canary run *per discovered property with a well-known mapping* (currently two: `UnoMaterial`, `UnoExtensions`). Negligible. |
+| Unintended fallback | The fallback is consulted only when a `WellKnownMappings` entry exists for the property fragment **and** the standard lookup looks suspicious (returned nothing, or returned a version older than the local reference). Packages outside the table take zero extra cost and zero behavior change. |
+| Direct (non-property) references to legacy IDs | Safe: see the suspicion gate. A repo with `<PackageVersion Include="Uno.Material" Version="5.0.13" />` (uno.toolkit.ui pattern) has local *behind* the latest legacy version, so the gate skips the fallback and the standard lookup wins. Verified by `GivenLocalBehindStandard_FallbackDoesNotFire` test. |
+
+## Test plan
+
+`src/NvGet.Tests/Tools/Updater/`
+
+- `PropertyPackageMappingsTests` — table lookups, including null/empty/unknown-key safety.
+- `PropertyPackageFallbackTests` — end-to-end via `UpdaterParametersExtension.GetLatestVersion`:
+  - `GivenOutdatedUnoExtensionsBase_FallbackPicksUnoExtensionsCore` (Studio scenario)
+  - `GivenOutdatedUnoMaterialBase_FallbackPicksUnoMaterialWinUI` (Studio scenario)
+  - `GivenOutdatedUnoThemesBase_FallbackPicksUnoThemesWinUI` (Uno.Toolkit scenario)
+  - `GivenBasePackageNewerThanFallback_FallbackIsNotPreferred` (forward-compat against base-package revival)
+  - `GivenLocalBehindStandard_FallbackDoesNotFire` (regression guard for direct PackageReference to legacy IDs)
+  - `GivenPackageWithoutMapping_NoFallbackAttempted` (no behavior change for non-mapped packages)
+  - `GivenBaseReturnsNothing_FallbackStillResolves` (legacy not present on feed)
+
+## Rollout plan
+
+After merge to `main`:
+
+1. Release new version of `Uno.NuGet.Updater.Tool` to NuGet.org (e.g. `1.3.0`).
+2. For each canary repo, single-line bump of `nugetUpdaterVersion:` in the canary-updater YAML. Listed approximately in order of latent impact:
+   - `unoplatform/uno.studio` — actively failing (Material)
+   - `unoplatform/Uno.Gallery` — exposed but unbroken
+   - `unoplatform/uno.extensions` — has dead `projectProperties:` line that can be removed
+   - `unoplatform/Uno.Themes`, `Uno.Playground`, `uno.toolkit.ui`, `uno.chefs`, `uno.rider`, `uno.csharpmarkup`, `uno.templates`
+3. Watch first nightly canary in each repo for `Applied property fallback mapping:` log lines and reduced skip count.
+4. Optional cleanup: revert per-repo workarounds that this change makes redundant (e.g. uno.studio's manual `UnoMaterialVersion` bumps on `canaries/dev`).
+
+## Audit methodology
+
+The well-known table was populated by scanning recent canary build logs across all 22 canary build definitions in the three relevant ADO projects (`Uno Platform`, `uno-private`, `Uno Rider Addin`). For each canary, the most recent build's `Canary Update` task log was fetched and filtered for the heuristic-mismatch pattern:
+
+```
+Skipping <lowercase.id>: version X found in <props>, version Y found in https://api.nuget.org/v3/index.json
+```
+
+where `Y < X` (the heuristic-derived package's latest version is older than what's already in the props, so the bump is silently skipped). Each candidate was then cross-checked against NuGet.org to verify a divergent modern variant exists with active dev versions, and against the canary repo source to confirm the real `<PackageReference>` uses the modern variant via the property.
+
+Three cases met the criteria as of 2026-05-22:
+
+| Canary | Property | Stale ID | Modern variant |
+|---|---|---|---|
+| Uno Studio | `UnoMaterialVersion` | `uno.material` 5.8.0-dev.2 | `Uno.Material.WinUI` |
+| Uno Studio | `UnoExtensionsVersion` | `uno.extensions` 3.0.0-dev.1957 | `Uno.Extensions.Core` |
+| Uno.Toolkit | `UnoThemesVersion` | `uno.themes` 5.8.0-dev.2 | `Uno.Themes.WinUI` |
+
+Cases observed in logs but **out of scope** (different bug class):
+
+| Canary | Pattern | Why excluded |
+|---|---|---|
+| Uno.CSharpMarkup | `Uno.UI` / `Uno.WinUI.Skia.Gtk` skip (direct `<PackageReference>`, not property-derived) | Both `Uno.UI` and `Uno.WinUI` are *actively maintained on parallel major lines* (5.x and 6.x). Not a "deprecated base" situation — the project's reference choice between them is intentional. Auto-redirecting would be an opinionated upgrade, not a bug fix. |
+| NuGetPackageExplorer | `Uno.Monaco.Editor 6.4.0-dev.41.gfc...` vs nuget.org `2.0.0-dev.60` | Private Azure Artifacts feed publishes a different version trajectory than nuget.org. Feed-priority/visibility issue, not heuristic mismatch. |
+| Various | `*.Bootstrap` skips with `0.0.0.0` | Intentional pins via `useVersionOverrides=` — opt-out by repo design. |
+| Various | `Skipping [X]: no dev version found` | Non-Uno packages correctly filtered by `packageAuthor=` — by design. |
+
+If new property→package mismatches are observed in future canary cycles, they can be added to `WellKnownMappings` with a single dict entry + one test method.
+
+## Future work (out of scope here)
+
+- **uno.csharpmarkup `Uno.UI` / `Uno.WinUI.Skia.Gtk` skips.** Different bug class — author/feed metadata mismatch, not property-name heuristic. Needs separate investigation.
+- **uno.extensions `projectProperties:` cleanup.** Their YAML references a non-existent task input; once this fix lands and the well-known table covers the cases they intended to map, that line can be removed.
+- **User-supplied fallback overrides.** Not shipped here. If a future canary repo needs a property-fragment → package mapping that isn't in the well-known table and *isn't* expressible via the existing `--updateProperties=` mechanism, a follow-up could add a new `--fallbackMappings=` CLI/task input. No demand observed today.
+
+## References
+
+- ADO build [213977 — Uno Studio Canary](https://dev.azure.com/uno-platform/uno-private/_build/results?buildId=213977)
+- ADO build [213950 — Uno.Gallery Canary](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=213950)
+- [Renovate issue #2266 — NuGet MSBuild property versions](https://github.com/renovatebot/renovate/issues/2266)
+- [The new Dependabot NuGet updater (Microsoft, 2024)](https://devblogs.microsoft.com/dotnet/the-new-dependabot-nuget-updater/)
+- [Microsoft Learn — Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management)

--- a/src/NvGet.Tests/Tools/Updater/PropertyPackageFallbackTests.cs
+++ b/src/NvGet.Tests/Tools/Updater/PropertyPackageFallbackTests.cs
@@ -1,0 +1,278 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Versioning;
+using NvGet.Entities;
+using NvGet.Tools.Tests.Entities;
+using NvGet.Tools.Updater.Entities;
+using NvGet.Tools.Updater.Extensions;
+
+namespace NvGet.Tests.Tools.Updater
+{
+	/// <summary>
+	/// End-to-end coverage for the well-known property→package fallback resolution
+	/// in <see cref="UpdaterParametersExtension.GetLatestVersion(UpdaterParameters, CancellationToken, PackageReference)"/>.
+	///
+	/// Real-world cases mirror canary build observations:
+	///  • Studio: UnoMaterialVersion / UnoExtensionsVersion silently skipped because the
+	///    name-derived base package (uno.material / uno.extensions) is stale on NuGet.org.
+	/// </summary>
+	[TestClass]
+	public class PropertyPackageFallbackTests
+	{
+		[TestMethod]
+		public async Task GivenOutdatedUnoExtensionsBase_FallbackPicksUnoExtensionsCore()
+		{
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.extensions", new[] { "3.0.0-dev.1957" } },        // stale legacy umbrella
+				{ "Uno.Extensions.Core", new[] { "7.3.0-dev.78" } },     // current modern package
+			});
+
+			var reference = new PackageReference("uno.extensions", "7.0.17");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version, "Fallback should have produced a version.");
+			Assert.AreEqual(NuGetVersion.Parse("7.3.0-dev.78"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenOutdatedUnoMaterialBase_FallbackPicksUnoMaterialWinUI()
+		{
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.material", new[] { "5.8.0-dev.2" } },           // stale legacy UWP package
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },    // current modern package
+			});
+
+			var reference = new PackageReference("uno.material", "7.0.0-dev.28");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("7.0.0-dev.33"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenOutdatedUnoThemesBase_FallbackPicksUnoThemesWinUI()
+		{
+			// Toolkit canary scenario: <UnoThemesVersion>7.0.0-dev.29</UnoThemesVersion> with
+			// <PackageVersion Include="Uno.Themes.WinUI" Version="$(UnoThemesVersion)" />.
+			// Without fallback the updater queries `uno.themes` (legacy 5.x) and silently skips.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.themes", new[] { "5.8.0-dev.2" } },           // stale legacy package
+				{ "Uno.Themes.WinUI", new[] { "7.0.0-dev.33" } },    // current modern package
+			});
+
+			var reference = new PackageReference("uno.themes", "7.0.0-dev.29");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("7.0.0-dev.33"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenBasePackageNewerThanFallback_FallbackIsNotPreferred()
+		{
+			// If the upstream ever revives the legacy base package and ships newer than the WinUI variant,
+			// we should still pick the higher version.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.material", new[] { "8.0.0-dev.10" } },          // hypothetically revived
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },
+			});
+
+			var reference = new PackageReference("uno.material", "5.0.0");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("8.0.0-dev.10"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenLocalEqualsStandard_FallbackDoesNotFire()
+		{
+			// Boundary of the suspicion gate: local == standard. Gate is strict (local > standard),
+			// so equality must NOT trigger the fallback. The standard lookup wins (returns the same
+			// version, no actual upgrade). This guards against a future off-by-one bug where someone
+			// might "tidy" the gate to >=.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.material", new[] { "5.8.0-dev.2" } },
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },
+			});
+
+			var reference = new PackageReference("uno.material", "5.8.0-dev.2");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("5.8.0-dev.2"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenLocalBehindStandard_FallbackDoesNotFire()
+		{
+			// Toolkit-style scenario: direct <PackageVersion Include="Uno.Material" Version="5.0.13" />
+			// (no property indirection). The legacy line is still alive at 5.8.0-dev.2 and we want to
+			// bump within the legacy line — NOT silently swap in Uno.Material.WinUI 7.x, which
+			// would write a version that doesn't exist for the original package ID and break restore.
+			//
+			// Suspicion gate: local (5.0.13) is NOT > standard (5.8.0-dev.2), so the fallback is skipped.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.material", new[] { "5.0.13", "5.8.0-dev.2" } },     // legacy line still alive
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },         // modern line ahead
+			});
+
+			var reference = new PackageReference("uno.material", "5.0.13");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("5.8.0-dev.2"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenPackageWithoutMapping_NoFallbackAttempted()
+		{
+			// Sanity: packages without a well-known mapping behave exactly as before.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "Uno.UI", new[] { "2.1.39", "2.2.0", "3.0.0-dev.2" } },
+			});
+
+			var reference = new PackageReference("Uno.UI", "2.1.39");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("3.0.0-dev.2"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenBothBaseAndFallbackAbsent_ReturnsNull()
+		{
+			// Edge case: neither the heuristic-derived package nor the fallback target exist on the feed.
+			// Should return null (no version available), not throw or return a stale value.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "SomeOtherPackage", new[] { "1.0.0" } },
+				// Neither uno.material nor Uno.Material.WinUI in the feed.
+			});
+
+			var reference = new PackageReference("uno.material", "7.0.0-dev.28");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNull(version);
+		}
+
+		[TestMethod]
+		public async Task GivenForcedVersionOverride_FallbackIsNotConsulted()
+		{
+			// Contract: --versionOverrides=file.json with `"UpdatedVersion": "X"` short-circuits
+			// the entire lookup before either standard or fallback resolution. The fallback must
+			// never override a forced version. Guards against a future refactor that reorders
+			// these checks.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "uno.material", new[] { "5.8.0-dev.2" } },
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },
+			});
+
+			var reference = new PackageReference("uno.material", "7.0.0-dev.28");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+			// Force-pin uno.material to a specific version that exists nowhere else.
+			parameters.VersionOverrides.Add("uno.material",
+				(forceVersion: true,
+				 upgradePolicy: UpgradePolicy.Major,
+				 range: new VersionRange(
+					minVersion: NuGetVersion.Parse("6.6.6-pinned"),
+					includeMinVersion: true,
+					maxVersion: NuGetVersion.Parse("6.6.6-pinned"),
+					includeMaxVersion: true,
+					floatRange: null,
+					originalString: null)));
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("6.6.6-pinned"), version.Version);
+		}
+
+		[TestMethod]
+		public async Task GivenBaseReturnsNothing_FallbackStillResolves()
+		{
+			// Edge case: legacy package not present on the feed at all.
+			// Fallback should still resolve a version.
+			var feed = new TestPackageFeed(Constants.TestFeedUri, new Dictionary<string, string[]>
+			{
+				{ "Uno.Material.WinUI", new[] { "7.0.0-dev.33" } },
+				// uno.material intentionally missing
+			});
+
+			var reference = new PackageReference("uno.material", "7.0.0-dev.28");
+			var parameters = new UpdaterParameters
+			{
+				TargetVersions = { "dev" },
+				Feeds = { feed },
+			};
+
+			var version = await parameters.GetLatestVersion(CancellationToken.None, reference);
+
+			Assert.IsNotNull(version);
+			Assert.AreEqual(NuGetVersion.Parse("7.0.0-dev.33"), version.Version);
+		}
+
+	}
+}

--- a/src/NvGet.Tests/Tools/Updater/PropertyPackageMappingsTests.cs
+++ b/src/NvGet.Tests/Tools/Updater/PropertyPackageMappingsTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NvGet.Tools.Updater.Entities;
+
+namespace NvGet.Tests.Tools.Updater
+{
+	[TestClass]
+	public class PropertyPackageMappingsTests
+	{
+		[TestMethod]
+		public void GivenUnoExtensions_WhenTryGetFallbackMapping_ReturnsUnoExtensionsCore()
+		{
+			var result = PropertyPackageMappings.TryGetFallbackMapping("UnoExtensions", out var fallbackPackageId, out var reason);
+
+			Assert.IsTrue(result);
+			Assert.AreEqual("Uno.Extensions.Core", fallbackPackageId);
+			Assert.IsTrue(reason.Contains("outdated"));
+		}
+
+		[TestMethod]
+		public void GivenUnoMaterial_WhenTryGetFallbackMapping_ReturnsUnoMaterialWinUI()
+		{
+			var result = PropertyPackageMappings.TryGetFallbackMapping("UnoMaterial", out var fallbackPackageId, out var reason);
+
+			Assert.IsTrue(result);
+			Assert.AreEqual("Uno.Material.WinUI", fallbackPackageId);
+			Assert.IsTrue(reason.Contains("outdated"));
+		}
+
+		[TestMethod]
+		public void GivenUnoThemes_WhenTryGetFallbackMapping_ReturnsUnoThemesWinUI()
+		{
+			var result = PropertyPackageMappings.TryGetFallbackMapping("UnoThemes", out var fallbackPackageId, out var reason);
+
+			Assert.IsTrue(result);
+			Assert.AreEqual("Uno.Themes.WinUI", fallbackPackageId);
+			Assert.IsTrue(reason.Contains("outdated"));
+		}
+
+		[TestMethod]
+		public void GivenUnknownProperty_WhenTryGetFallbackMapping_ReturnsFalse()
+		{
+			var result = PropertyPackageMappings.TryGetFallbackMapping("UnknownProperty", out var fallbackPackageId, out var reason);
+
+			Assert.IsFalse(result);
+			Assert.IsNull(fallbackPackageId);
+			Assert.IsNull(reason);
+		}
+
+		[TestMethod]
+		public void GivenUnoToolkit_WhenTryGetFallbackMapping_ReturnsFalse()
+		{
+			// UnoToolkit / UnoWinui / UnoResizetizer / UnoTemplates intentionally not mapped:
+			// their derived lowercase IDs match real, current packages on NuGet.org.
+			var result = PropertyPackageMappings.TryGetFallbackMapping("UnoToolkit", out var fallbackPackageId, out var reason);
+
+			Assert.IsFalse(result);
+			Assert.IsNull(fallbackPackageId);
+			Assert.IsNull(reason);
+		}
+
+		[TestMethod]
+		public void GivenNull_WhenTryGetFallbackMapping_ReturnsFalse()
+		{
+			var result = PropertyPackageMappings.TryGetFallbackMapping(null, out var fallbackPackageId, out var reason);
+
+			Assert.IsFalse(result);
+			Assert.IsNull(fallbackPackageId);
+			Assert.IsNull(reason);
+		}
+	}
+}

--- a/src/NvGet/Tools/Updater/Entities/PropertyPackageMappings.cs
+++ b/src/NvGet/Tools/Updater/Entities/PropertyPackageMappings.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace NvGet.Tools.Updater.Entities
+{
+	/// <summary>
+	/// Well-known fallback mappings for MSBuild version properties whose name-derived
+	/// package ID points at an outdated/deprecated base package on NuGet.org.
+	///
+	/// Example: <c>&lt;UnoMaterialVersion&gt;</c> derives to <c>uno.material</c> (legacy UWP package),
+	/// but the project actually consumes <c>Uno.Material.WinUI</c>. Without a fallback the updater
+	/// silently skips the property because the derived base package's latest version is older
+	/// than the property's current value.
+	/// </summary>
+	/// <remarks>
+	/// User-supplied explicit property→package mappings can be provided via the existing
+	/// <c>--updateProperties=</c> CLI argument (or the <c>useUpdateProperties</c> +
+	/// <c>updatePropertiesFile</c> ADO task inputs). This well-known list is a built-in
+	/// safety net for the common cases that every canary repo would otherwise need to configure.
+	/// </remarks>
+	public static class PropertyPackageMappings
+	{
+		/// <summary>
+		/// Well-known property-fragment → fallback package mappings for Uno Platform packages.
+		/// Key: property name with the trailing "Version" stripped (e.g. "UnoMaterial" for "UnoMaterialVersion").
+		/// Value: tuple of (canonical package ID to look up instead, human-readable reason for logs).
+		/// </summary>
+		/// <remarks>
+		/// Kept private so the table is genuinely immutable from the outside; the only supported access
+		/// path is <see cref="TryGetFallbackMapping(string, out string, out string)"/>. New entries should
+		/// be added here (with a one-line comment + one test method) when a new property→package
+		/// mismatch is observed in production canary build logs.
+		/// </remarks>
+		private static readonly IReadOnlyDictionary<string, (string FallbackPackageId, string Reason)> WellKnownMappings =
+			new Dictionary<string, (string, string)>
+			{
+				// Legacy `uno.material` (UWP-era) is at v5.x and stale.
+				// Modern consumers reference `Uno.Material.WinUI` (currently 7.x).
+				["UnoMaterial"] = ("Uno.Material.WinUI", "Base package Uno.Material is outdated; resolving against Uno.Material.WinUI."),
+
+				// Legacy `uno.themes` (UWP-era) is at v5.x and stale.
+				// Modern consumers reference `Uno.Themes.WinUI` (and the related `Uno.Simple.WinUI`,
+				// which ships in lockstep with Themes.WinUI); using Uno.Themes.WinUI as the lookup.
+				["UnoThemes"] = ("Uno.Themes.WinUI", "Base package Uno.Themes is outdated; resolving against Uno.Themes.WinUI."),
+
+				// Legacy umbrella `uno.extensions` is at v2.x.
+				// Modern consumers reference Uno.Extensions.* family packages (currently 7.x);
+				// the family ships in lockstep so Uno.Extensions.Core is a safe canonical lookup.
+				["UnoExtensions"] = ("Uno.Extensions.Core", "Base package Uno.Extensions is outdated; resolving against Uno.Extensions.Core."),
+			};
+
+		/// <summary>
+		/// Looks up a well-known fallback for a given property-fragment.
+		/// </summary>
+		/// <param name="propertyNameWithoutVersion">Property name with the "Version" suffix stripped (e.g. "UnoExtensions").</param>
+		/// <param name="fallbackPackageId">The canonical package ID to look up instead, or <c>null</c> if no mapping exists.</param>
+		/// <param name="reason">Human-readable reason for logs, or <c>null</c> if no mapping exists.</param>
+		/// <returns><c>true</c> when a well-known mapping is registered for the given property fragment.</returns>
+		public static bool TryGetFallbackMapping(
+			string propertyNameWithoutVersion,
+			out string fallbackPackageId,
+			out string reason)
+		{
+			fallbackPackageId = null;
+			reason = null;
+
+			if (string.IsNullOrEmpty(propertyNameWithoutVersion))
+			{
+				return false;
+			}
+
+			if (WellKnownMappings.TryGetValue(propertyNameWithoutVersion, out var mapping))
+			{
+				fallbackPackageId = mapping.FallbackPackageId;
+				reason = mapping.Reason;
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/NvGet/Tools/Updater/Extensions/UpdaterParametersExtension.cs
+++ b/src/NvGet/Tools/Updater/Extensions/UpdaterParametersExtension.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NvGet.Contracts;
 using NvGet.Entities;
@@ -101,6 +102,51 @@ namespace NvGet.Tools.Updater.Extensions
 				? value
 				: new string[] { null }; // Invoke GetPackageVersions with a null parameter
 
+			var result = await ResolveLatestVersion(parameters, ct, reference, authors, manualVersion);
+
+			// Built-in safety net: when the property-name-derived package ID is a known outdated/deprecated
+			// base package (e.g. uno.material → 5.x stale; modern consumers reference Uno.Material.WinUI),
+			// also look up the canonical replacement and prefer it when it returns a newer version.
+			//
+			// Suspicion gate: only consider the fallback if the standard lookup looks broken — either it
+			// returned nothing, or it returned a version *older* than the reference's current version
+			// (a strong signal that the local file is tracking the modern variant via property indirection
+			// while the heuristic-derived package ID is a frozen/legacy line). When the standard lookup
+			// returns a newer version than the local reference, the heuristic-derived package is still
+			// alive and we must not overwrite it with the fallback's version — that would write a version
+			// that doesn't exist for the original package ID and break the restore.
+			//
+			// Users who need explicit, non-fallback property→package mappings should use --updateProperties=.
+			var standardIsSuspicious = result == null || reference.Identity.Version > result.Version;
+			if(standardIsSuspicious)
+			{
+				var propertyFragment = ConvertPackageIdToPropertyFragment(reference.Identity.Id);
+				if(PropertyPackageMappings.TryGetFallbackMapping(propertyFragment, out var fallbackPackageId, out var reason))
+				{
+					var fallbackReference = new PackageReference(
+						new PackageIdentity(fallbackPackageId, reference.Identity.Version),
+						reference.Files
+					);
+					var fallbackResult = await ResolveLatestVersion(parameters, ct, fallbackReference, authors, manualVersion);
+
+					if(fallbackResult != null && (result == null || fallbackResult.Version > result.Version))
+					{
+						PackageFeed.Logger.LogInformation($"Applied property fallback mapping: {reference.Identity.Id} -> {fallbackPackageId} ({reason})");
+						result = fallbackResult;
+					}
+				}
+			}
+
+			return result;
+		}
+
+		private static async Task<FeedVersion> ResolveLatestVersion(
+			UpdaterParameters parameters,
+			CancellationToken ct,
+			PackageReference reference,
+			string[] authors,
+			(bool forceVersion, UpgradePolicy upgradePolicy, VersionRange range) manualVersion)
+		{
 			var availableVersions = await Task.WhenAll(parameters
 				.Feeds
 				.SelectMany(f => authors.Select(author => f.GetPackageVersions(ct, reference, author)))
@@ -122,6 +168,34 @@ namespace NvGet.Tools.Updater.Extensions
 				.Select(g => g.FirstOrDefault())
 				.OrderByDescending(v => v.Version)
 				.FirstOrDefault();
+		}
+
+		/// <summary>
+		/// Best-effort title-casing of a dot-separated lowercase package ID into a property-name
+		/// fragment, used as a lookup key against <c>PropertyPackageMappings.WellKnownMappings</c>.
+		/// </summary>
+		/// <remarks>
+		/// This is NOT a true inverse of the property-name → package-id heuristic in
+		/// <c>XmlDocumentExtensions.GetPackageReferences</c>: that heuristic lowercases everything,
+		/// so acronym information is lost on the forward path. For example, both
+		/// <c>UnoWinUIVersion</c> → <c>uno.win.ui</c> and <c>UnoWinuiVersion</c> → <c>uno.winui</c>
+		/// are valid forward conversions, but this helper can only produce a single output per input
+		/// (<c>UnoWinUi</c> and <c>UnoWinui</c> respectively). The well-known table is therefore keyed
+		/// by the fragment this helper actually produces; entries with acronyms must match accordingly.
+		/// All current entries (<c>UnoMaterial</c>, <c>UnoThemes</c>, <c>UnoExtensions</c>) avoid
+		/// the ambiguity.
+		/// </remarks>
+		internal static string ConvertPackageIdToPropertyFragment(string packageId)
+		{
+			if(string.IsNullOrEmpty(packageId))
+			{
+				return packageId;
+			}
+
+			var parts = packageId.Split('.');
+			return string.Concat(parts.Select(p => p.Length == 0
+				? string.Empty
+				: char.ToUpperInvariant(p[0]) + (p.Length > 1 ? p.Substring(1) : string.Empty)));
 		}
 
 		private static bool IsUpgradable(


### PR DESCRIPTION
GitHub Issue (If applicable): _None — surfaced by canary build audit_

## PR Type

- Feature

## What is the current behavior?

When an MSBuild version property (e.g. `<UnoMaterialVersion>7.0.0-dev.28</UnoMaterialVersion>`) is discovered during XML scan, the updater derives a package ID by stripping `Version`, splitting at camel-case boundaries, lowercasing, and joining with dots (`UnoMaterialVersion` → `uno.material`). This works for properties whose derived ID matches a real, actively-maintained package on NuGet.org.

It silently fails when the derived ID points at a legacy/deprecated package whose version trajectory has diverged from what the project actually consumes. Repos affected in production today (verified across the full canary build audit on `Uno Platform`, `uno-private`, `Uno Rider Addin` projects):

| Repo | Property | Derived ID returns | Real package | Real latest dev |
|---|---|---|---|---|
| Uno.Studio | `UnoMaterialVersion` | `uno.material` 5.8.0-dev.2 (legacy UWP) | `Uno.Material.WinUI` | 7.0.0-dev.33 |
| Uno.Studio | `UnoExtensionsVersion` | `uno.extensions` 3.0.0-dev.1957 (legacy umbrella) | `Uno.Extensions.Core` (family lockstep) | 7.3.0-dev.78 |
| Uno.Toolkit | `UnoThemesVersion` | `uno.themes` 5.8.0-dev.2 (legacy UWP) | `Uno.Themes.WinUI` | 7.0.0-dev.33 |

In each case the canary updater queries the legacy ID, finds a version *older* than what's already in `Directory.Build.props`, treats it as a non-upgrade, and silently skips. Studio's canary failed 10+ consecutive nights with `NU1605` once an upstream Uno.Toolkit canary advanced its `Uno.Material.WinUI ≥ 7.0.0-dev.29` floor past Studio's frozen `7.0.0-dev.28`.

## What is the new behavior?

A small built-in `PropertyPackageMappings` table (private; only `TryGetFallbackMapping` is exposed) that the updater consults **after** the standard per-feed lookup, gated by a *suspicion signal*: the fallback only fires when the standard result is `null` or has a version *strictly older* than the local reference (signal that the local file is tracking the modern variant via property indirection and the derived legacy ID is a frozen line).

Resolution algorithm:

```text
result := standard lookup
if result is null OR reference.Version > result.Version:
  if WellKnownMappings contains ConvertPackageIdToPropertyFragment(reference.Id):
    fallback := lookup with the mapped canonical package ID
    if fallback is not null AND (result is null OR fallback.Version > result.Version):
      result := fallback
return result
```

Initial well-known table:

| Property fragment | Falls back to | Reason |
|---|---|---|
| `UnoMaterial` | `Uno.Material.WinUI` | Legacy `uno.material` (UWP era) at v5.x is stale; modern consumers reference the WinUI 3 variant. |
| `UnoThemes` | `Uno.Themes.WinUI` | Legacy `uno.themes` (UWP era) at v5.x is stale; modern consumers reference the WinUI 3 variant (and `Uno.Simple.WinUI` ships in lockstep). |
| `UnoExtensions` | `Uno.Extensions.Core` | Legacy umbrella `uno.extensions` at v2.x is stale; modern consumers reference the `Uno.Extensions.*` family in lockstep. |

Users who need explicit, non-fallback property→package mappings should continue to use the existing `--updateProperties=` CLI argument (or the `useUpdateProperties` + `updatePropertiesFile` ADO task inputs). The well-known table is purely a built-in safety net for the common cases that every canary repo would otherwise need to configure individually.

**Suspicion gate** prevents a regression risk for repos with direct `<PackageVersion Include="Uno.Material" Version="5.0.13" />` references (e.g. uno.toolkit.ui pattern) where the legacy line is still actively consumed at 5.x. Without the gate the fallback would have rewritten such references to `Uno.Material.WinUI`'s 7.x version, which doesn't exist for the original package ID and would break restore. With the gate, the standard lookup wins for those cases (5.0.13 → 5.8.0-dev.2 on the legacy line) and the fallback stays out of the way. Verified end-to-end against a mixed-fixture (Studio-style property + Toolkit-style direct ref in one tree) and covered by three boundary tests: `GivenLocalBehindStandard_FallbackDoesNotFire`, `GivenLocalEqualsStandard_FallbackDoesNotFire`, `GivenBasePackageNewerThanFallback_FallbackIsNotPreferred`.

See [`specs/property-package-fallback-mappings/spec.md`](https://github.com/unoplatform/nuget.updater/blob/main/specs/property-package-fallback-mappings/spec.md) for the full design, audit methodology, and rollout plan.

## PR Checklist

- [x] Tested code with current supported SDKs (net8.0 + net9.0 — both build and test green)
- [x] Docs have been added/updated — `doc/nuget-updater.md` gets a new "Property → package resolution" section (including the canonical convention comment quoted from real repos); full design lives in `specs/property-package-fallback-mappings/spec.md`. `CHANGELOG.md` updated under `[Unreleased] > ### Added`; new `specs/README.md` documents the convention for future spec contributors to this repo.
- [x] Unit Tests and/or UI Tests for the changes have been added — 16 new tests (6 unit + 10 end-to-end including suspicion-gate boundary tests, `VersionOverrides` short-circuit, and both-base-and-fallback-absent edge case); `Passed!  - Failed: 0, Passed: 64, Skipped: 1, Total: 65`
- [x] Contains **NO** API breaking changes — purely additive (new file + new safety-net logic gated by suspicion check; well-known table is private). Behavior change: properties previously silently-skipped will now auto-bump (this *is* the fix). Existing `--updateProperties=` and `--versionOverrides=` behavior unchanged (verified by `GivenForcedVersionOverride_FallbackIsNotConsulted` test).
- [x] Updated CHANGELOG
- [ ] Associated with an issue — surfaced by canary audit; not tracked in a separate issue

## Other information

### Rollout (after merge + release)

1. Publish new `Uno.NuGet.Updater.Tool` version to NuGet.org (e.g. `1.2.11`).
2. Bump `nugetUpdaterVersion:` one-liner in each canary YAML across affected repos: uno.studio, Uno.Gallery, Uno.Themes, Uno.Playground, uno.extensions, uno.toolkit.ui, uno.chefs, uno.rider, uno.csharpmarkup, uno.templates.
3. Watch the first canary build in each repo for `Applied property fallback mapping:` log lines and reduced `## Skipped` count.

### Out of scope (flagged in spec for follow-up)

- **uno.csharpmarkup** `Uno.UI` / `Uno.WinUI.Skia.Gtk` skip — *different bug class* (both packages actively maintained on parallel major lines on NuGet.org; not a deprecated-base situation). Needs a content/configuration change in the csharpmarkup repo, not this tool.
- **uno.extensions** canary YAML has a `projectProperties:` line that doesn't exist as a task input — silently no-op since 2025-08. Can be removed after this lands (the well-known table covers their `MauiUnoVersion` / `NonMauiUnoVersion` intent indirectly via `UnoExtensions` → `Uno.Extensions.Core`, and if they need anything more specific the existing `useUpdateProperties:true` + `updatePropertiesFile:` is the right path).
- **`unoplatform/uno/doc/articles/migrating-to-uno-5.md`** uses `$UnoWinUIVersion$` as a `dotnet new` template variable in a csproj snippet — separate repo, separate fix (will be filed independently).

Internal Issue (If applicable): n/a

